### PR TITLE
Make direct content write possible

### DIFF
--- a/djlibcloud/storage.py
+++ b/djlibcloud/storage.py
@@ -222,9 +222,9 @@ class LibCloudStorage(Storage):
         # TOFIX : we should be able to read chunk by chunk
         return next(self.driver.download_object_as_stream(obj, obj.size))
 
-    def _save(self, name, content):
+    def _save(self, name, file):
         extra = {'acl': 'public-read'}
-        self.driver.upload_object_via_stream(iter(content.file),
+        self.driver.upload_object_via_stream(iter(file),
                                              self._get_bucket(),
                                              name, extra=extra)
         return name

--- a/djlibcloud/storage.py
+++ b/djlibcloud/storage.py
@@ -222,9 +222,9 @@ class LibCloudStorage(Storage):
         # TOFIX : we should be able to read chunk by chunk
         return next(self.driver.download_object_as_stream(obj, obj.size))
 
-    def _save(self, name, file):
+    def _save(self, name, content):
         extra = {'acl': 'public-read'}
-        self.driver.upload_object_via_stream(iter(file),
+        self.driver.upload_object_via_stream(iter(getattr(content, "file", content)),
                                              self._get_bucket(),
                                              name, extra=extra)
         return name


### PR DESCRIPTION
Given the examples below, I will get `AttributeError: '_io.BytesIO' object has no attribute 'file'`

``` python
# File - settings.py
DEFAULT_FILE_STORAGE = 'djlibcloud.storage.LibCloudStorage'
```

``` python
# File - write.py
from django.core.files.storage import default_storage
snippet = "my content"
file = default_storage.open("path_here", 'w')
file.write(bytes(snippet))
file.close()

```
